### PR TITLE
add hooks to capture event and entity names as they are registered

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Spawn anything and everything, vehicles, characters, animals, props. Enable infi
  - ***OPTIONAL*** - Enable super fast game loading with the `-quickstart` launch argument via Steam
 
 ### Commands
- - `spawn` - Spawn everything! Vehicles, characters, animals & props.
+ - `spawn` - Spawn everything! Vehicles, characters, animals & props. By default, autocomplete displays suggestions for "spawn specifiers," or adjectives that describe entities (e.g. "vehicle," "weapon," or "sniper"). Chain multiple of these together with commas to narrow down which entities to choose from, or, instead, place a `!` at the start of the parameter to see suggestions for entity names to spawn directly.
  - `event` - Trigger game events - **CAUTION** - Stick to using only the hints, unless you know what the event does
  - `world` - Change world parameters
 

--- a/src/commands/command.h
+++ b/src/commands/command.h
@@ -5,6 +5,11 @@
 class ICommand
 {
   public:
+    virtual void Initialize()
+    {
+        return;
+    }
+
     virtual const char*              GetCommand()                           = 0;
     virtual bool                     Handler(const std::string& arguments)  = 0;
     virtual std::vector<std::string> GetHints(const std::string& arguments) = 0;

--- a/src/commands/event.h
+++ b/src/commands/event.h
@@ -6,13 +6,21 @@
 class EventCommand : public ICommand
 {
   public:
-    inline static std::set<std::string> m_Hints = {};
+    inline static std::set<std::string>       m_Hints = {};
+    inline const static std::set<std::string> banned  = {
+		"load_game",
+		"new_game",
+		"continue_game",
+		"pause_game"
+	};
 
     virtual void Initialize() override
     {
         static hk::inject_jump<void, int64_t, char*, char, bool> add_event_hook(0x140089870);
         add_event_hook.inject([](int64_t _, char* eventName, char flags, bool unknown) {
-			m_Hints.insert(eventName);
+            if (banned.find(eventName) == banned.end()) {
+				m_Hints.insert(eventName);
+            }
             add_event_hook.call(_, eventName, flags, unknown);
 		});
     }
@@ -24,7 +32,7 @@ class EventCommand : public ICommand
 
     virtual bool Handler(const std::string& arguments) override
     {
-        if (arguments == "load_game" || arguments == "new_game" || arguments == "continue_game") {
+        if (banned.find(arguments) != banned.end()) {
             return false;
         }
 

--- a/src/commands/event.h
+++ b/src/commands/event.h
@@ -10,14 +10,11 @@ class EventCommand : public ICommand
 
     virtual void Initialize() override
     {
-        hk::inject_jump<void, int64_t, char*, char, bool> add_event_hook(0x140089870);
-        add_event_hook.inject(AddEvent);
-    }
-
-    static void AddEvent(int64_t _, char* eventName, char flags, bool unknown)
-    {
-        m_Hints.insert(eventName);
-        hk::func_call<void>(0x143FEF670, _, eventName, flags, unknown);
+        static hk::inject_jump<void, int64_t, char*, char, bool> add_event_hook(0x140089870);
+        add_event_hook.inject([](int64_t _, char* eventName, char flags, bool unknown) {
+			m_Hints.insert(eventName);
+            add_event_hook.call(_, eventName, flags, unknown);
+		});
     }
 
     virtual const char* GetCommand() override

--- a/src/commands/event.h
+++ b/src/commands/event.h
@@ -1,25 +1,24 @@
 #pragma once
 
 #include "command.h"
+#include <set>
 
 class EventCommand : public ICommand
 {
   public:
-    std::array<const char*, 13> m_Hints = {
-        "__showfps",
-        "__reload_world",
-        "ply.unlimitedammo.enable",
-        "ply.unlimitedammo.disable",
-        "ply.ammo.givemax",
-        "ply.pause",
-        "ply.unpause",
-        "ply.vehicle.burn",
-        "moon_gravity_on",
-        "moon_gravity_off",
-        "debug.vehicle.incrementtint",
-        "vocals.rico.enable",
-        "vocals.rico.disable",
-    };
+    inline static std::set<std::string> m_Hints = {};
+
+    virtual void Initialize() override
+    {
+        hk::inject_jump<void, int64_t, char*, char, bool> add_event_hook(0x140089870);
+        add_event_hook.inject(AddEvent);
+    }
+
+    static void AddEvent(int64_t _, char* eventName, char flags, bool unknown)
+    {
+        m_Hints.insert(eventName);
+        hk::func_call<void>(0x143FEF670, _, eventName, flags, unknown);
+    }
 
     virtual const char* GetCommand() override
     {

--- a/src/commands/spawn.h
+++ b/src/commands/spawn.h
@@ -7,6 +7,8 @@
 
 class SpawnCommand : public ICommand
 {
+
+#pragma pack(push, 1)
     struct PropertyFileEntry {
         uint32_t hash;
         uint32_t data;
@@ -18,6 +20,7 @@ class SpawnCommand : public ICommand
         PropertyFileEntry *entry;
         uint8_t            error;
     };
+#pragma pack(pop)
 
     struct Spawnable {
         std::string              model;

--- a/src/commands/spawn.h
+++ b/src/commands/spawn.h
@@ -30,7 +30,13 @@ class SpawnCommand : public ICommand
     inline static const std::string delims = ", |";
 
   public:
-    inline static std::vector<Spawnable> m_Hints = {};
+    inline static std::vector<Spawnable>      m_Hints = {};
+    inline const static std::set<std::string> banned  = {
+		"rico_debug",
+		"rico_preview_debug",
+		"rico_cow_skin",
+		"rico_cow_skin_debug"
+	};
 
     virtual void Initialize() override
     {
@@ -45,8 +51,10 @@ class SpawnCommand : public ICommand
 
             if (model.entry && specifiers.entry) {
                 s.model      = (char *)(model.base + model.entry->data);
-                s.specifiers = SplitSpecifiers((char *)(specifiers.base + specifiers.entry->data));
-                m_Hints.push_back(s);
+                if (banned.find(s.model) == banned.end()) {
+					s.specifiers = SplitSpecifiers((char *)(specifiers.base + specifiers.entry->data));
+					m_Hints.push_back(s);
+				}
             }
 
             return add_event_hook.call(file, buf, hash);
@@ -88,7 +96,7 @@ class SpawnCommand : public ICommand
         transform.m[3].y = aimpos.y + 1.0f;
         transform.m[3].z = aimpos.z;
 
-        if (arguments.length() == 0) {
+        if (arguments.length() == 0 || banned.find(arguments) != banned.end()) {
             return false;
         }
 

--- a/src/commands/spawn.h
+++ b/src/commands/spawn.h
@@ -1,472 +1,76 @@
 #pragma once
 
 #include "command.h"
+#include <algorithm>
+#include <iostream>
+#include <set>
 
 class SpawnCommand : public ICommand
 {
-  public:
-    // clang-format off
-    std::array<const char *, 426> m_Hints = {
-        // VEHICLES
-        "v000_car_atv_civilian_01",
-        "v000_car_atv_javi",
-        "v001_car_forklift_industrial",
-        "v002_car_vintagesuv_civilian",
-        "v002_car_vintagesuv_javi",
-        "v002_car_vintagesuv_rebel",
-        "v003_car_crane_industrial",
-        "v004_car_articulatedtruck_commercial_01",
-        "v004_car_articulatedtruck_commercial_cargo_trailer",
-        "v004_car_articulatedtruck_commercial_lowloader_trailer",
-        "v004_car_articulatedtruck_commercial_radarjammer",
-        "v004_car_articulatedtruck_commercial_smallmobileweapon_trailer",
-        "v005_car_wheelloader_industrial",
-        "v006_car_conveyorcrane_industrial",
-        // "v007_car_",
-        "v008_car_taxitrike_civilian",
-        "v009_car_armoredtruck_commercial_01",
-        "v010_car_oldtractor_civilian_01",
-        "v011_car_oldtwodoorhatch_civilian_01",
-        "v011_car_oldtwodoorhatch_sargento",
-        "v012_car_apc_military_01",
-        "v012_car_apc_rebel_01",
-        "v013_car_armoredtransport_military_01",
-        "v013_car_armoredtransport_rebel_01",
-        "v014_car_offroadtruck_military_01",
-        "v014_car_offroadtruck_rebel_01",
-        "v015_car_cannontruck_military",
-        "v015_car_cannontruck_rebel",
-        "v016_car_armoredarticulatedtruck_military",
-        "v016_car_armoredarticulatedtruck_rebel",
-        "v017_car_vintagemuscle_bomb_special",
-        "v017_car_vintagemuscle_civilian",
-        "v017_car_vintagemuscle_civilian_02",
-        "v017_car_vintagemuscle_rico",
-        "v018_car_monstertruck_bomb_special",
-        "v018_car_monstertruck_civilian_01",
-        "v019_car_modernlimo_bomb_special",
-        "v019_car_modernlimo_civilian_01",
-        "v020_car_moderngrandtourer_civilian_01",
-        "v021_car_sportsmuscle_bomb_special",
-        "v021_car_sportsmuscle_civilian_01",
-        "v022_car_moderncircuitracer_bomb_special",
-        "v022_car_moderncircuitracer_civilian_01",
-        "v023_car_racingsuper_bomb_special",
-        "v023_car_racingsuper_civilian_01",
-        "v023_car_racingsuper_racing_01",
-        "v024_car_ecosuper_bomb_special",
-        "v024_car_ecosuper_civilian_01",
-        "v024_car_ecosuper_racing_01",
-        "v025_car_vintagesuper_bomb_special",
-        "v025_car_vintagesuper_civilian_01",
-        "v026_car_vintagesports_bomb_special",
-        "v026_car_vintagesports_civilian_01",
-        "v027_car_hurricanetruck_civilian",
-        "v027_car_hurricanetruck_tesla",
-        "v027_car_hurricanetruck_transport",
-        // "v028_car_",
-        "v029_car_smallmodernsedan_civilian_01",
-        "v029_car_smallmodernsedan_civilian_02",
-        "v030_car_oldmini_civilian_01",
-        "v030_car_oldmini_civilian_02",
-        "v031_car_racinghothatch_civilian_01",
-        "v031_car_racinghothatch_encounter_takedown",
-        "v032_car_luxurysportssedan_civilian_01",
-        "v033_car_modernmini_civilian_01",
-        "v033_car_modernmini_civilian_02",
-        "v034_car_oldtruck_commercial_01",
-        "v034_car_oldtruck_commercial_cargo_barrel",
-        "v034_car_oldtruck_commercial_cargo_barrel_mission_special",
-        "v034_car_oldtruck_commerical_cargo_random",
-        "v034_car_oldtruck_commerical_cargo_sargento_intro",
-        "v035_car_modernvan_civic_ambulance_01",
-        "v035_car_modernvan_commerical_01",
-        "v035_car_modernvan_garland",
-        "v036_car_modernpickup_civilian_01",
-        "v036_car_modernpickup_civilian_02",
-        "v037_car_modernbus_commerical_01",
-        "v038_car_modernsuv_civilian_01",
-        "v038_car_modernsuv_civilian_02",
-        "v039_car_oldcampervan_civilian_01",
-        "v039_car_oldcampervan_civilian_02",
-        "v040_car_oldcompact_civilian_01",
-        "v040_car_oldcompact_sargento",
-        // "v041_car_",
-        "v042_car_racingsedan_civilian",
-        "v042_car_racingsedan_racing_01",
-        // "v043_car_",
-        // "v044_car_",
-        "v045_car_minetruck_commercial_01",
-        "v046_car_racingbuggy_civilian",
-        "v046_car_racingbuggy_military",
-        "v046_car_racingbuggy_racing_01",
-        // "v047_car_",
-        // "v048_car_",
-        // "v049_car_",
-        "v050_car_toyjeep_civilian",
-
-        // boats
-        "v100_boat_fanboat_civilian",
-        "v101_boat_smalljet_military",
-        "v101_boat_smalljet_rebel",
-        "v102_boat_heavypatrol_lightning",
-        "v102_boat_heavypatrol_military_01",
-        "v102_boat_heavypatrol_rebel_01",
-        "v103_boat_corvette_military_01",
-        "v103_boat_corvette_rebel_01",
-        "v104_boat_landingtransport_commercial",
-        "v104_boat_landingtransport_commercial_lightningrod_escort",
-        "v104_boat_landingtransport_commercial_signal_jammer",
-        "v104_boat_landingtransport_rebel",
-        "v105_boat_sailboat_civilian_01",
-        "v106_boat_motoryacht_bomb_special",
-        "v106_boat_motoryacht_civilian_01",
-        "v107_boat_racingboat_bomb_special",
-        "v107_boat_racingboat_civilian_01",
-        "v108_boat_largeoldfishing_civilian_01",
-        "v108_boat_largeoldfishing_civilian_01_garland_intro",
-        "v109_boat_ferry_commercial",
-        "v109_boat_ferry_commercial_garlandintro",
-        "v110_boat_jetski_civilian_01",
-
-        // helicopters
-        "v200_helicopter_heavylift_military",
-        "v200_helicopter_heavylift_rebel_01",
-        "v200_helicopter_heavylift_rebel_mission_special",
-        "v200_helicopter_heavytroop_mira",
-        "v201_helicopter_mediumattack_military_01",
-        "v201_helicopter_mediumattack_rebel_01",
-        "v202_helicopter_lightheavytroop_gabriela",
-        "v202_helicopter_lightheavytroop_military_01",
-        "v202_helicopter_lightheavytroop_rebel_01",
-        "v203_helicopter_lightattack_military_01",
-        "v203_helicopter_lightattack_rebel_01",
-        "v204_helicopter_heavyassault_military_01",
-        "v204_helicopter_heavyassault_rebel_01",
-        "v205_helicopter_utility_civilian_01",
-        "v205_helicopter_utility_commercial_news",
-        "v205_helicopter_utility_garland",
-        "v206_helicopter_bubblescout_civilian_01",
-        "v206_helicopter_bubblescout_javi",
-        "v250_helicopter_mediumattackdrone_military",
-        "v250_helicopter_mediumattackdrone_rebel",
-        "v250_helicopter_mediumattackdrone_tornado",
-        "v251_helicopter_rocketdrone_military",
-        "v251_helicopter_rocketdrone_rebel",
-        "v252_helicopter_suicidedrone_military",
-        "v252_helicopter_suicidedrone_rebel",
-        "v253_helicopter_decoydrone_preorder",
-        "v253_helicopter_decoydrone_rebel",
-        "v254_helicopter_guarddrone_military",
-        "v254_helicopter_guarddrone_rebel",
-
-        // bikes
-        "v301_bike_combatdirt_military_01",
-        "v301_bike_combatdirt_rebel_01",
-        // "v302_bike_",
-        "v303_bike_modernsuper_bomb_special",
-        "v303_bike_modernsuper_civilian_01",
-        "v304_bike_modernsport_bomb_special",
-        "v304_bike_modernsport_civilian_01",
-        "v305_bike_oldroad_civilian_01",
-        "v306_bike_modernroad_civilian_01",
-        "v307_bike_oldmoped_civilian_01",
-        "v308_bike_trials_civilian_01",
-        "v308_bike_trials_javi",
-
-        // planes
-        "v400_plane_fighterjet_military_01",
-        "v400_plane_fighterjet_rebel_01",
-        "v401_plane_cargotransport_military_01",
-        "v401_plane_cargotransport_rebel_01",
-        "v401_plane_cargotransport_signal_jammer",
-        "v402_plane_fighterbomber_military_01",
-        "v402_plane_fighterbomber_rebel_01",
-        "v403_plane_microjet_military",
-        "v403_plane_microjet_rebel",
-        "v404_plane_privatejet_civilian",
-        "v405_plane_commercialcargo_commercial",
-        "v406_plane_smallprop_civilian_01",
-        "v407_plane_mediumprop_civilian_01",
-        "v408_plane_ultralight_civilian",
-
-        // trains
-        "v500_train_industrialengine_industrial",
-        "v500_train_industrialengine_rebel",
-        "v501_train_containercarriage_industrial",
-        "v501_train_containercarriage_rebel",
-        "v502_train_armoredengine_military_01",
-        "v502_train_armoredengine_military_01_mission_special_steal_the_weapon_tech",
-        "v502_train_armoredengine_military_01_node_military_05",
-        "v502_train_armoredengine_military_02",
-        "v502_train_armoredengine_military_03",
-        "v502_train_armoredengine_military_04",
-        "v502_train_armoredengine_rebel",
-        "v502_train_armoredengine_rebel_02",
-        "v502_train_armoredengine_rebel_04",
-        "v502_train_armoredengine_rebel_mission_special_outro",
-        "v502_train_armoredengine_rebel_mission_special_sandstorm_finale",
-        "v503_train_armoredcargocarriage_military_catwalk",
-        "v503_train_armoredcargocarriage_military_containers",
-        "v503_train_armoredcargocarriage_military_empty",
-        "v503_train_armoredcargocarriage_rebel",
-        "v503_train_armoredcargocarriage_rebel_containers",
-        "v503_train_armoredcargocarriage_rebel_empty",
-        "v503_train_armoredcargocarriage_rebel_empty_decouple_immune",
-        "v504_train_armoredfuelcarriage_military",
-        "v504_train_armoredfuelcarriage_rebel",
-        "v504_train_armoredfuelcarriage_rebel_not_targetable",
-        "v505_train_armoredweaponcarriage_military_01",
-        "v505_train_armoredweaponcarriage_rebel",
-        "v506_train_armoredhowitzer_base",
-        "v506_train_armoredhowitzer_military",
-        "v506_train_armoredhowitzer_military_covered",
-        "v506_train_armoredhowitzer_rebel",
-        "v506_train_armoredhowitzer_decouple_immune",
-
-        // treaded
-        "v800_treaded_modernheavytank_military_01",
-        "v800_treaded_modernheavytank_rebel_01",
-        "v801_treaded_mediumtank_military_01",
-        "v801_treaded_mediumtank_rebel_01",
-        "v802_treaded_aatank_military",
-        "v802_treaded_aatank_rebel",
-        "v803_treaded_flexturrettank_military",
-        "v803_treaded_flexturrettank_rebel",
-        "v804_treaded_snowmobile_civilian",
-        "v804_treaded_snowmobile_civilian_mission_special",
-
-        // balloon
-        "v700_balloon_dirigible_civilian",
-        "v700_balloon_dirigible_collectible",
-        "v700_balloon_dirigible_military_01",
-        "v700_balloon_dirigible_node_science_01",
-
-        // trailers
-        "v901_trailer_cartransport_commercial",
-        "v902_trailer_lowloader_commerical",
-        "v902_trailer_lowloader_mobile_radar_folded",
-        "v902_trailer_lowloader_mobile_radar_folded_sargento_aiproxy_enabled",
-        "v902_trailer_lowloader_mobile_radar_upright",
-        "v902_trailer_lowloader_mobile_radar_upright_sargent_aiproxy_enabled",
-        "v903_trailer_cargo_commerical",
-        "v904_trailer_smallmobileweapon_military",
-        "v904_trailer_smallmobileweapon_rebel",
-        // "v905_trailer_",
-        // "v906_trailer_",
-        "v907_trailer_radarjammer_military",
-
-        // WEAPONS
-        "wpn_000_assault_rifle",
-        "wpn_001_assault_rifle",
-        "wpn_003_assault_rifle",
-        "wpn_010_machine_gun",
-        "wpn_011_machine_gun",
-        "wpn_020_shotgun",
-        "wpn_021_shotgun",
-        "wpn_022_shotgun",
-        "wpn_030_sniper_rifle",
-        "wpn_031_sniper_rifle",
-        "wpn_032_sniper_rifle",
-        "wpn_040_combat_rifle",
-        "wpn_050_smg",
-        "wpn_060_rpg",
-        "wpn_061_rpg",
-        "wpn_063_rpg",
-        "wpn_070_glauncher",
-        "wpn_071_mlauncher",
-        "wpn_080_experimental",
-        "wpn_081_experimental",
-        "wpn_100_railgun",
-        "wpn_102_crossbow",
-        "w206_mounted_capstone_m2hm",
-        "wpn_201_minigun",
-        "wpn_201_minigun_mount",
-        "wpn_201_minigun_mount_rebel",
-        "wpn_201_minigun_mount_military",
-        "w301_grenade",
-        "w303_concussion_grenade",
-        "w304_death_dropped_grenade",
-        "wpn_202_cannon",
-        "wpn_202_cannon_rebel",
-        "wpn_203_aa_gun",
-        "wpn_203_aa_gun_rebel",
-        "wpn_204_mortar_mounted",
-        "wpn_204_mortar_mounted_rebel",
-        "illapa_defence_weapon",
-        "cow_gun",
-        "wpn_990_premium_wingsuit_bullet_streamer",
-
-        // CHARACTERS
-        "cow",
-        "bull",
-        "deer_doe",
-        "deer_buck",
-        "dog",
-        "goat",
-        "tapir",
-        "llama",
-        "llama_02",
-        "llama_03_sheared",
-        "capybara",
-        "domestic_pig",
-        "feral_hog",
-        "wild_boar",
-        "civ_alpine_scientist_female",
-        "civ_alpine_scientist_male",
-        "civ_scientist_female",
-        "civ_scientist_male",
-        "civ_alpine_worker_female_01",
-        "civ_alpine_worker_male_01",
-        "civ_node_hacker_male_01",
-        "civ_node_hacker_male_02",
-        "civ_node_hacker_male_03",
-        "civ_node_hacker_male_04",
-        "civ_techengineer_female",
-        "civ_techengineer_male",
-        "civ_miner_male",
-        "civ_construction_worker_female_01",
-        "civ_construction_worker_male_01",
-        "civ_lumberyard_female_01",
-        "civ_lumberyard_male_01",
-        "civ_mechanic_female_01",
-        "civ_mechanic_male_01",
-        "civ_steelworker_female_01",
-        "civ_steelworker_male_01",
-        "civ_evil_target_female_01",
-        "civ_evil_target_male_01",
-        "civ_garland_crew_female_01",
-        "civ_garland_crew_male_01",
-        "civ_garland_location_scout_001",
-        "civ_garland_pa_001",
-        "civ_garland_pa_male_01",
-        "civ_garland_stuntperson_helmet_female_01",
-        "civ_garland_stuntperson_helmet_male_01",
-        "civ_javi_soldier_001",
-        "civ_javi_soldier_full_body",
-        "civ_sargento_soldier_female_01",
-        "civ_sargento_soldier_male_01",
-        "civ_prisoner_female",
-        "civ_prisoner_male",
-        "civ_bolo_santosi_01",
-        "civ_brrd_male_01",
-        "civ_greenman_female_01",
-        "civ_greenman_male_01",
-        "civ_rome_male_01",
-        "civ_beachgoer_female_01",
-        "civ_beachgoer_male_01",
-        "civ_dockworker_female_01",
-        "civ_dockworker_male_01",
-        "civ_favela_female_01",
-        "civ_favela_male_01",
-        "civ_rainforest_female_01",
-        "civ_rainforest_male_01",
-        "civ_desert_female_01",
-        "civ_desert_male_01",
-        "civ_grasslands_female_01",
-        "civ_grasslands_male_01",
-        "civ_business_female_01",
-        "civ_business_male_01",
-        "civ_vagrant_female_001",
-        "civ_vagrant_male_001",
-        "civ_athletic_female_001",
-        "civ_athletic_male_001",
-        "civ_soccer_aa_female_01",
-        "civ_soccer_aa_male_01",
-        "civ_soccer_esp_female_01",
-        "civ_soccer_esp_male_01",
-        "civ_soccer_female_001",
-        "civ_soccer_male_001",
-        "civ_upperclass_female_01",
-        "civ_upperclass_male_01",
-        "civ_farmer_female_01",
-        "civ_farmer_male_01",
-        "civ_bartender_female_01",
-        "civ_bartender_male_01",
-        "civ_airport_worker_female_01",
-        "civ_airport_worker_male_01",
-        "civ_art_vendor_female_01",
-        "civ_art_vendor_male_01",
-        "civ_factory_worker_female_01",
-        "civ_factory_worker_male_01",
-        "civ_food_vendor_female_01",
-        "civ_food_vendor_male_01",
-        "civ_gas_station_female_01",
-        "civ_gas_station_male_01",
-        "civ_graffitiartist_female_01",
-        "civ_graffitiartist_male_01",
-        "civ_street_musician_female_01",
-        "civ_street_musician_male_01",
-        "elite_enemy_001",
-        "ghost_enemy_001",
-        "grenadier_enemy_001",
-        "machinegunner_enemy_001",
-        "elite_paratrooper",
-        "private_enemy_001",
-        "private_enemy_002",
-        "rpg_enemy_001",
-        "shielder_enemy_001",
-        "sniper_enemy_001",
-        "super_elite_enemy_001",
-        "titan_enemy_001",
-        "sargentos_rebel_female_01",
-        "sargentos_rebel_female_02",
-        "sargentos_rebel_female_03",
-        "sargentos_rebel_male_01",
-        "sargentos_rebel_male_02",
-        "sargentos_rebel_male_03",
-        "female_rebel_001",
-        "female_rebel_002",
-        "female_rebel_003",
-        "female_rebel_004",
-        "female_rebel_prisoner_01",
-        "female_rebel_prisoner_02",
-        "female_rebel_prisoner_03",
-        "female_rebel_tier_1_01",
-        "female_rebel_tier_1_02",
-        "female_rebel_tier_1_03",
-        "female_rebel_tier_2_01",
-        "female_rebel_tier_2_02",
-        "female_rebel_tier_2_03",
-        "female_rebel_tier_3_01",
-        "female_rebel_tier_3_02",
-        "female_rebel_tier_3_03",
-        "male_rebel_001",
-        "male_rebel_002",
-        "male_rebel_003",
-        "male_rebel_004",
-        "male_rebel_prisoner_01",
-        "male_rebel_prisoner_02",
-        "male_rebel_prisoner_03",
-        "male_rebel_tier_1_01",
-        "male_rebel_tier_1_02",
-        "male_rebel_tier_1_03",
-        "male_rebel_tier_1_04",
-        "male_rebel_tier_2_01",
-        "male_rebel_tier_2_02",
-        "male_rebel_tier_2_03",
-        "male_rebel_tier_2_04",
-        "male_rebel_tier_3_01",
-        "male_rebel_tier_3_02",
-        "male_rebel_tier_3_03",
-        "male_rebel_tier_3_04",
-        "civ_female_aha_dancer_follower",
-        "cesar",
-        "dictator",
-        "dictator_guard",
-        "gabriela",
-        "garland",
-        "izzy",
-        "javi",
-        "lanza",
-        "miguel_rodriguez",
-        "mira",
-        "oscar",
-        "oscar_young",
-        "sargento",
-        "sheldon",
+    struct PropertyFileEntry {
+        uint32_t hash;
+        uint32_t data;
+        uint8_t  type;
     };
-    // clang-format on
+
+    struct PropertyFileResult {
+        uint8_t *          base;
+        PropertyFileEntry *entry;
+        uint8_t            error;
+    };
+
+    struct Spawnable {
+        std::string              model;
+        std::vector<std::string> specifiers;
+    };
+
+    inline static const std::string delims = ", |";
+
+  public:
+    inline static std::vector<Spawnable> m_Hints = {};
+
+    virtual void Initialize() override
+    {
+        hk::inject_call<PropertyFileResult *, void *, PropertyFileResult *, uint32_t> add_event_hook(0x140A08310);
+        add_event_hook.inject(AddModelName);
+    }
+
+    static std::vector<std::string> SplitSpecifiers(const std::string &input)
+    {
+        std::vector<std::string> result;
+        size_t                   lastDelim = 0;
+        size_t                   i;
+        for (i = 0; i < input.length(); i++) {
+            if (delims.find(input.at(i)) != std::string::npos) {
+                if (i > lastDelim) {
+                    result.push_back(std::string(&input[lastDelim], i - lastDelim));
+                }
+                lastDelim = i + 1;
+            }
+        }
+        if (i > lastDelim) {
+            result.push_back(std::string(&input[lastDelim], i - lastDelim));
+        }
+        return result;
+    }
+
+    static PropertyFileResult *AddModelName(void *file, PropertyFileResult *buf, uint32_t hash)
+    {
+        Spawnable          s;
+        PropertyFileResult model;
+        PropertyFileResult specifiers;
+
+        hk::func_call<PropertyFileResult *>(0x140087E60, file, &model, 0xF71C2A21);
+        hk::func_call<PropertyFileResult *>(0x140087E60, file, &specifiers, 0x54697E8F);
+
+        if (model.entry && specifiers.entry) {
+            s.model      = (char *)(model.base + model.entry->data);
+            s.specifiers = SplitSpecifiers((char *)(specifiers.base + specifiers.entry->data));
+            m_Hints.push_back(s);
+        }
+
+        return hk::func_call<PropertyFileResult *>(0x140087E60, file, buf, hash);
+    }
 
     virtual const char *GetCommand() override
     {
@@ -475,16 +79,27 @@ class SpawnCommand : public ICommand
 
     virtual bool Handler(const std::string &arguments) override
     {
-        auto  local_player = jc::CPlayerManager::instance().m_localPlayer;
-        auto  transform    = local_player->m_character->m_transform;
-        auto &aimpos       = local_player->m_aimControl->m_aimPos;
+        std::string spawner;
+        auto        local_player = jc::CPlayerManager::instance().m_localPlayer;
+        auto        transform    = local_player->m_character->m_transform;
+        auto &      aimpos       = local_player->m_aimControl->m_aimPos;
 
         transform.m[3].x = aimpos.x;
         transform.m[3].y = aimpos.y + 1.0f;
         transform.m[3].z = aimpos.z;
 
+        if (arguments.length() == 0) {
+            return false;
+        }
+
+        if (arguments.at(0) == '!') {
+            spawner = arguments.substr(1);
+        } else {
+            spawner = arguments;
+        }
+
         // TODO(aaronlad): figure out the flags, right now the game is holding the shared_ptr so we don't have to do it
-        jc::CSpawnSystem::instance().Spawn(arguments, transform, [](const jc::spawned_objects &objects, void *) {
+        jc::CSpawnSystem::instance().Spawn(spawner, transform, [](const jc::spawned_objects &objects, void *) {
             //
         });
 
@@ -493,10 +108,46 @@ class SpawnCommand : public ICommand
 
     virtual std::vector<std::string> GetHints(const std::string &arguments) override
     {
-        std::vector<std::string> result;
-        std::copy_if(m_Hints.begin(), m_Hints.end(), std::back_inserter(result),
-                     [&](const std::string &item) { return item.find(arguments) != std::string::npos; });
+        if (arguments.length() > 0 && arguments.at(0) == '!') {
+            std::string            content = arguments.substr(1);
+            std::vector<Spawnable> intermediates;
+            std::set<std::string>  results;
 
-        return result;
+            std::vector<std::string> userSpecifiers = SplitSpecifiers(content);
+            std::string              last           = "";
+            if (userSpecifiers.size() > 0 && delims.find(content.back()) == std::string::npos) {
+                last = userSpecifiers.back();
+                userSpecifiers.pop_back();
+            }
+
+            std::string base = content.substr(0, content.length() - last.length());
+
+            std::copy_if(m_Hints.begin(), m_Hints.end(), std::back_inserter(intermediates), [&](const Spawnable &item) {
+                return std::all_of(userSpecifiers.begin(), userSpecifiers.end(), [&](const std::string &user) {
+                    return std::find(item.specifiers.begin(), item.specifiers.end(), user) != item.specifiers.end();
+                });
+            });
+
+            for (Spawnable &item : intermediates) {
+                for (std::string &specifier : item.specifiers) {
+                    if (specifier.find(last) != std::string::npos) {
+                        results.insert("!" + base + specifier);
+                    }
+                }
+            }
+
+            return std::vector(results.begin(), results.end());
+        } else {
+            std::vector<Spawnable>   intermediates;
+            std::vector<std::string> result;
+
+            std::copy_if(m_Hints.begin(), m_Hints.end(), std::back_inserter(intermediates), [&](const Spawnable &item) {
+                return item.model.find(arguments) != std::string::npos;
+            });
+            std::transform(intermediates.begin(), intermediates.end(), std::back_inserter(result),
+                           [](const Spawnable &item) -> std::string { return item.model; });
+
+            return result;
+        }
     }
 };

--- a/src/input.h
+++ b/src/input.h
@@ -38,11 +38,13 @@ class Input : public Singleton<Input>
 
     void RegisterCommand(std::unique_ptr<ICommand> cmd)
     {
+        cmd->Initialize();
         m_commands[cmd->GetCommand()] = std::move(cmd);
     }
 
     void RegisterCommand(const std::string& command, std::unique_ptr<ICommand> cmd)
     {
+        cmd->Initialize();
         m_commands[command] = std::move(cmd);
     }
 


### PR DESCRIPTION
Add a hook in the event registration function in order to capture events for autocompletion in the console.

Additionally, add a hook in the property file parser for spawnable objects in order to capture both entity names and "spawn specifiers" for autocomplete. In particular, users can choose which set to show hints from: by default, show hints from entity names, but, if the arguments begin with a `!`, parse the string into its corresponding specifiers (handled by the game at 0x140A083DE, though reimplemented in this commit), and display suggestions from the set of specifiers that correspond to the currently-possible entities.

Definitely open to suggestions on the code; this is my first even-remotely-serious C++ project!