### PR TITLE
Crash fix for Steam version

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     // exit if not jc4
-    if (!GetModuleHandle("JustCause4.exe")) {
+    if (!GetModuleHandle("JustCause4.exe") && !GetModuleHandle("JustCause4GameCL.exe")) {
         return FALSE;
     }
 


### PR DESCRIPTION
With my Steam version of JC4 GetModuleHandle("JustCause4.exe") returns false and makes the game crash, either with the Steam launcher or LaunchWithDropzone.exe.
Now it also checks for "JustCause4GameCL.exe" and it works.