### PR TITLE
Added new tp commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Spawn anything and everything, vehicles, characters, animals, props. Enable infi
    - `tp save <name>` - Save current coordinates as named location
    - `tp <name>` - Go to saved named location
    - `tp delete <name>` - Delete saved named location
+   - `tp get <name>` - Prints position of named location
+   - `tp printpos` - Prints current player position
 
 ### Controls
  - `Tilde` (\`~) or `F1` - Toggle the input box

--- a/src/commands/command.h
+++ b/src/commands/command.h
@@ -5,8 +5,8 @@
 class ICommand
 {
   public:
-    virtual const char*              GetCommand() = 0;
-    virtual void                     Init(){};
-    virtual bool                     Handler(const std::string& arguments)  = 0;
-    virtual std::vector<std::string> GetHints(const std::string& arguments) = 0;
+    virtual const char*						GetCommand() = 0;
+    virtual void							Init(){};
+    virtual std::pair<bool, std::string>	Handler(const std::string& arguments)  = 0; // Returns success, and command output (if any)
+    virtual std::vector<std::string>		GetHints(const std::string& arguments) = 0;
 };

--- a/src/commands/event.h
+++ b/src/commands/event.h
@@ -10,16 +10,16 @@ class EventCommand : public ICommand
         return "event";
     }
 
-    virtual bool Handler(const std::string& arguments) override
+    virtual std::pair<bool, std::string> Handler(const std::string& arguments) override
     {
         using namespace jc;
 
         if (arguments == "load_game" || arguments == "new_game" || arguments == "continue_game") {
-            return false;
+            return {false, ""};
         }
 
         meow_hook::func_call<void>(GetAddress(SEND_EVENT), arguments.c_str(), nullptr);
-        return true;
+        return {true, ""};
     }
 
     virtual std::vector<std::string> GetHints(const std::string& arguments) override

--- a/src/commands/skin.h
+++ b/src/commands/skin.h
@@ -10,15 +10,15 @@ class SkinCommand : public ICommand
         return "skin";
     }
 
-    virtual bool Handler(const std::string& arguments) override
+    virtual std::pair<bool, std::string> Handler(const std::string& arguments) override
     {
         std::vector<jc::CSpawnSystem::SResourceDef*, jc::allocator<jc::CSpawnSystem::SResourceDef*>> resources;
         if (jc::CSpawnSystem::instance().GetMatchingResources(arguments, &resources)) {
             jc::CPlayerManager::instance().GetLocalPlayerCharacter()->ChangeSkin(resources[0]->m_resourcePath);
-            return true;
+            return {true, ""};
         }
 
-        return false;
+        return {false, ""};
     }
 
     virtual std::vector<std::string> GetHints(const std::string& arguments) override

--- a/src/commands/spawn.h
+++ b/src/commands/spawn.h
@@ -10,11 +10,11 @@ class SpawnCommand : public ICommand
         return "spawn";
     }
 
-    virtual bool Handler(const std::string &arguments) override
+    virtual std::pair<bool, std::string> Handler(const std::string &arguments) override
     {
         if (arguments == "rico_debug" || arguments == "rico_preview_debug" || arguments == "rico_cow_skin"
             || arguments == "rico_cow_skin_debug") {
-            return false;
+            return {false, ""};
         }
 
         auto  local_player = jc::CPlayerManager::instance().m_localPlayer;
@@ -27,7 +27,7 @@ class SpawnCommand : public ICommand
 
         // NOTE(aaronlad): spawn flag 0x8000 will prevent auto despawn
         jc::CSpawnSystem::instance().Spawn(arguments, transform, [](const jc::spawned_objects &objects, void *) {});
-        return true;
+        return {true, ""};
     }
 
     virtual std::vector<std::string> GetHints(const std::string &arguments) override

--- a/src/commands/world.h
+++ b/src/commands/world.h
@@ -10,7 +10,7 @@ class WorldCommand : public ICommand
         return "world";
     }
 
-    virtual bool Handler(const std::string& arguments) override
+    virtual std::pair<bool, std::string> Handler(const std::string& arguments) override
     {
         using namespace jc;
 
@@ -25,7 +25,7 @@ class WorldCommand : public ICommand
             if (sscanf_s(arguments.c_str(), "time %f", &time) == 1) {
                 time = std::clamp(time, -24.0f, 24.0f);
                 meow_hook::func_call<void>(GetAddress(WORLDTIME_SET_TIME), WorldTime, time, 2);
-                return true;
+                return {true, ""};
             }
         }
         // time scale
@@ -33,7 +33,7 @@ class WorldCommand : public ICommand
             float timescale = 1.0f;
             if (sscanf_s(arguments.c_str(), "timescale %f", &timescale) == 1) {
                 *(float*)((char*)WorldTime + 0xE4) = std::clamp(timescale, -1000.0f, 1000.0f);
-                return true;
+                return {true, ""};
             }
         }
         // gravity
@@ -41,16 +41,16 @@ class WorldCommand : public ICommand
             float gravity = DEFAULT_GRAVITY;
             if (sscanf_s(arguments.c_str(), "gravity %f", &gravity) == 1) {
                 *(float*)((char*)hnpkWorld + 0x974) = std::clamp(gravity, -5000.0f, 5000.0f);
-                return true;
+                return {true, ""};
             }
         }
         // reset gravity
         else if (arguments.find("resetgravity") != std::string::npos) {
             *(float*)((char*)hnpkWorld + 0x974) = DEFAULT_GRAVITY;
-            return true;
+            return {true, ""};
         }
 
-        return false;
+        return {false, ""};
     }
 
     virtual std::vector<std::string> GetHints(const std::string& arguments) override

--- a/src/input.h
+++ b/src/input.h
@@ -23,6 +23,7 @@ class Input : public Singleton<Input>
     std::string              m_cmdText        = "";
     std::string              m_cmdArguments   = "";
     std::vector<std::string> m_hints;
+    std::string              m_commandOutput  = "";
     int32_t                  m_selectedHint   = -1;
     int32_t                  m_hintPage       = 0;
     bool                     m_controlPressed = false;


### PR DESCRIPTION
I was messing around in Just Cause 4 and wanted to know my current location, so I added two new commands. Users can now do `tp printpos` and `tp get <name>`. In both instances, the output is returned from the command and displayed below the autocomplete suggestions. This also makes it so that any command can now return things to the console. The output is cleared upon running a new command, and on commands where output is returned, the console window does not close instantly.

![autocomplete](https://user-images.githubusercontent.com/24510135/97118611-dbcdc080-1702-11eb-9326-9b0fb5bb123b.png)

![un-autocomplete](https://user-images.githubusercontent.com/24510135/97118618-e5572880-1702-11eb-9a0e-a643118549c2.png)

Thanks for this mod by the way, it makes Just Cause 3 and 4 10x more fun 👍 